### PR TITLE
refactor: update current_commit output to use pull request head SHA

### DIFF
--- a/.github/workflows/dev-prerelease.yml
+++ b/.github/workflows/dev-prerelease.yml
@@ -54,7 +54,7 @@ jobs:
 
           echo "mod_changed=$MOD_CHANGED" >> $GITHUB_OUTPUT
           echo "launcher_changed=$LAUNCHER_CHANGED" >> $GITHUB_OUTPUT
-          echo "current_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "current_commit=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
 
           # Generate commits with hash for correlation
           git log "$BASE_REF"..HEAD --pretty=format:"- %h: %s" --no-merges \


### PR DESCRIPTION
- Changed current_commit output to reference the pull request head SHA instead of the commit SHA.